### PR TITLE
Add column actions

### DIFF
--- a/src/MasterCRUD.php
+++ b/src/MasterCRUD.php
@@ -76,9 +76,6 @@ class MasterCRUD extends \atk4\ui\View
         //var_Dump($this->tabs->url());
         $this->tabs->stickyGet($this->model->table.'_id');
 
-        if ($this->getCaption($this->rootModel) !== $this->getCaption($m)) {
-            $this->crumb->addCrumb($this->getCaption($m), $this->tabs->url());
-        }
         $this->crumb->addCrumb($this->getTitle($m), $this->tabs->url());
 
         $form = $this->tabs->addTab($this->detailLabel)->add('Form');
@@ -90,12 +87,14 @@ class MasterCRUD extends \atk4\ui\View
 
 
         foreach($defs as $ref=>$subdef) {
-            if (is_numeric($ref) || $ref == 'menuActions') {
+            if (is_numeric($ref) || $ref == 'menuActions' || $ref == 'caption') {
                 continue;
             }
             $m = $this->model->ref($ref);
 
-            $this->tabs->addTab($this->getCaption($m), function($p) use($subdef, $m, $ref) {
+            $caption = $ref; // $this->getCaption($m);
+
+            $this->tabs->addTab($caption, function($p) use($subdef, $m, $ref) {
 
                 $this->sub_crud = $p->add($this->getCRUDSeed($subdef));
 
@@ -225,9 +224,6 @@ class MasterCRUD extends \atk4\ui\View
             // load record and traverse
             $m->load($arg_val);
 
-            if ($this->getCaption($this->rootModel) !== $this->getCaption($m)) {
-                $this->crumb->addCrumb($this->getCaption($m), $this->url(['path'=>$this->getPath($path_part)]));
-            }
             $this->crumb->addCrumb($this->getTitle($m), $this->url([
                 'path'=>$this->getPath($path_part)
             ]));

--- a/src/MasterCRUD.php
+++ b/src/MasterCRUD.php
@@ -182,7 +182,7 @@ class MasterCRUD extends \atk4\ui\View
                     );
                 }
 
-                if (is_callable($action)) {
+                if ($action instanceof Closure) {
                     $crud->menu->addItem($key)->on(
                         'click', 
                         new \atk4\ui\jsModal('Executing '.$key, $this->add('VirtualPage')->set(function($p) use($key, $action) { 
@@ -222,7 +222,7 @@ class MasterCRUD extends \atk4\ui\View
                     });
                 };
 
-                if (is_callable($action)) {
+                if ($action instanceof Closure) {
                     $crud->addModalAction($key, $key, function($p, $id) use($action, $crud) {
                         call_user_func($action, $p, $crud->model->load($id));
                     });

--- a/src/MethodExecutor.php
+++ b/src/MethodExecutor.php
@@ -42,6 +42,7 @@ class MethodExecutor extends \atk4\ui\View
         parent::init();
 
         $this->console = $this->add(['Console', 'event'=>false]);//->addStyle('display', 'none');
+        $this->console->addStyle('max-height', '50em')->addStyle('overflow', 'scroll');
 
         $this->form = $this->add('Form');
 

--- a/src/MethodExecutor.php
+++ b/src/MethodExecutor.php
@@ -1,0 +1,97 @@
+<?php
+namespace atk4\mastercrud;
+
+
+/**
+ * This component will display a form and a console. After filling out the form, the values
+ * will be passed on to the model / method of your choice and the execution of that method
+ * will be displayed in the console.
+ *
+ * $app->add(new MethodExecutior($user, 'generatePassword', ['integer']));
+ *
+ * Possible values of 3rd argument would be:
+ *
+ *  - string, would define 'type'=>$type explicitly, e.g. 'boolean' or 'date'.
+ *  - callback, would be executed and return value used.  function() { return 123; }
+ *  - array - use a seed for creating model field
+ */
+
+class MethodExecutor extends \atk4\ui\View
+{
+    use \atk4\core\SessionTrait;
+
+    public $model = null;
+
+    public $method = null;
+
+    public $arguments = null;
+
+    public $defs = null;
+
+    function __construct(\atk4\data\Model $model, $method, $defs = [])
+    {
+        parent::__construct([
+            'model'=>$model,
+            'method'=>$method,
+            'defs'=>$defs
+        ]);
+    }
+
+
+    function init() {
+        parent::init();
+
+        $this->console = $this->add(['Console', 'event'=>false]);//->addStyle('display', 'none');
+
+        $this->form = $this->add('Form');
+
+        foreach($this->defs as $key=>$val) {
+            if (is_numeric($key)) {
+                $key = 'Argument'.$key;
+            }
+
+            if (is_callable($val)) {
+                continue;
+            }
+
+            if ($val instanceof \atk4\data\Model) {
+                $this->form->addField($key, ['AutoComplete'])->setModel($val);
+            } else {
+                $this->form->addField($key, null, $val);
+            }
+        }
+
+        $this->form->buttonSave->set('Run');
+
+        $this->form->onSubmit(function($f) {
+            $this->memorize('data', $f->model ? $f->model->get(): []);
+
+            return [$this->console->js()->show(), $this->console->sse];
+        });
+
+        $this->console->set(function($c) {
+            $data = $this->recall('data');
+            $args = [];
+
+            foreach($this->defs as $key=>$val) {
+                if (is_numeric($key)) {
+                    $key = 'Argument'.$key;
+                }
+
+                if (is_callable($val)) {
+                    $val = $val($this->model, $this->method, $data);
+                } elseif ($val instanceof \atk4\data\Model) {
+                    $val->load($data[$key]);
+                } else {
+                    $val = $data[$key];
+                }
+
+                $args[] = $val;
+            }
+
+
+            $c->setModel($this->model, $this->method, $args);
+        });
+    }
+
+}


### PR DESCRIPTION
Added support for 'columnActions':

<img width="1319" alt="screen shot 2018-07-11 at 13 11 01" src="https://user-images.githubusercontent.com/453929/42570469-e39f87b6-850b-11e8-8661-c9b31665fbc0.png">

``` php
$app->layout->add(new \atk4\mastercrud\MasterCRUD())
    ->setModel(new \saasty\Model\App($app->db), 
    [
        'columnActions'=>[
            'repair'=>'wrench',
        ],
        'Models'=>[
            'columnActions'=>[
                'migrate'=>'database',
            ],
            'Fields'=>[
                'ValidationRules'=>[],
            
            ],
            'Relations'=>[
                'ImportedFields'=>[],
            ],
        ],
```

there are various invocation methods allowing you to specify icon, label, custom callbacks etc.

This also adds "MethodInvocator" - a view which asks you for arguments and then executes them.

This next example will use form to ask for an email, which will then be passed as argument to sendEmail($email)

``` php
[
    'columnActions'=>[
         'sendEmail' => ['icon'=>'wrench', 'email'=>'string']
   ]
]
```
