### PR TITLE
[fix] - Table Column Link Url

### DIFF
--- a/src/MasterCRUD.php
+++ b/src/MasterCRUD.php
@@ -180,7 +180,12 @@ class MasterCRUD extends View
                 $t = $p->urlTrigger ?: $p->name;
 
                 if (isset($sub_crud->table->columns[$m->title_field])) {
-                    $sub_crud->addDecorator($m->title_field, [Table\Column\Link::class, [$t => false, 'path' => $this->getPath($ref)], [$m->table . '_id' => 'id']]);
+                    // DEV-Note
+                    // This cause issue since https://github.com/atk4/ui/pull/1397 cause it will always include __atk_callback argument.
+                    // $sub_crud->addDecorator($m->title_field, [Table\Column\Link::class, [$t => false, 'path' => $this->getPath($ref)], [$m->table . '_id' => 'id']]);
+
+                    // Creating url template in order to produce proper url.
+                    $sub_crud->addDecorator($m->title_field, [Table\Column\Link::class, 'url' => $this->app->url(['path' => $this->getPath($ref)]) . '&' . $m->table . '_id=' . '{$id}']);
                 }
 
                 $this->addActions($sub_crud, $subdef);


### PR DESCRIPTION
Since UI PR: https://github.com/atk4/ui/pull/1397  the '__atk_callback' argument is always include in $table->url($p)
causing the critical error:

Critical Error
atk4\ui\Exception: Callback requested, but never reached. You may be missing some arguments in the request URL.

This fix will prevent '__atk-callback' to be set using url template instead of page arguments.
